### PR TITLE
fix: edited media not upload when using Gutenburg

### DIFF
--- a/aliyun-oss.php
+++ b/aliyun-oss.php
@@ -4,8 +4,8 @@
  * Description: 使用阿里云 OSS 作为附件的存储空间。 This is a plugin that used Aliyun OSS for attachments remote saving.
  * Author: Ivan Chou
  * Author URI: https://yii.im/
- * Version: 3.4.1
- * Updated_at: 2022-09-25
+ * Version: 3.4.2
+ * Updated_at: 2023-01-14
  */
 
 /*  Copyright 2016  Ivan Chou  (email : yiichou@gmail.com)
@@ -30,16 +30,23 @@ define('ALIYUN_OSS_MATEDATA_URL', 'https://chou.oss-cn-hangzhou.aliyuncs.com/ali
 require(ALIYUN_OSS_PATH . '/autoload.php');
 
 use OSS\WP\Config;
-Config::init(ALIYUN_OSS_PATH);
 
-if (Config::$staticHost) {
-    new OSS\WP\UrlHelper();
-}
-if (Config::$ossClient) {
-    Config::$disableUpload || new OSS\WP\Upload(Config::$ossClient);
-    new OSS\WP\Delete(Config::$ossClient);
+function init() {
+    Config::init(ALIYUN_OSS_PATH);
+
+    if (Config::$staticHost) {
+        new OSS\WP\UrlHelper();
+    }
+
+    if (Config::$ossClient) {
+        Config::$disableUpload || new OSS\WP\Upload(Config::$ossClient);
+        new OSS\WP\Delete(Config::$ossClient);
+    }
 }
 
 if (is_admin()) {
     new OSS\WP\Setting();
 }
+
+add_filter('admin_init', 'init');
+add_filter('rest_api_init', 'init', 800);

--- a/aliyun-oss.php
+++ b/aliyun-oss.php
@@ -31,11 +31,17 @@ require(ALIYUN_OSS_PATH . '/autoload.php');
 
 use OSS\WP\Config;
 
-function init() {
-    Config::init(ALIYUN_OSS_PATH);
+Config::init(ALIYUN_OSS_PATH);
 
-    if (Config::$staticHost) {
-        new OSS\WP\UrlHelper();
+if (Config::$staticHost) {
+    new OSS\WP\UrlHelper();
+}
+
+function init() {
+    Config::initOssClient();
+
+    if (is_admin()) {
+        new OSS\WP\Setting();
     }
 
     if (Config::$ossClient) {
@@ -44,9 +50,6 @@ function init() {
     }
 }
 
-if (is_admin()) {
-    new OSS\WP\Setting();
-}
 
 add_filter('admin_init', 'init');
 add_filter('rest_api_init', 'init', 800);

--- a/src/Config.php
+++ b/src/Config.php
@@ -112,13 +112,13 @@ class Config
             return;
         }
 
-        if (!is_admin() && empty($_FILES)) {
+        if (!is_admin() && $_FILES && !current_user_can( 'edit_posts' ) && !defined( 'REST_REQUEST' )) {
             return;
         }
 
         try {
             self::$ossClient = new OssClient(self::$accessKeyId, self::$accessKeySecret, self::$endpoint);
-        } catch (OssException $e) {
+        } catch (\Exception $e) {
             $html = "<div id='oss-warning' class='error fade'><p>%s: %s</p></div>";
             echo sprintf($html, __('Aliyun OSS', 'aliyun-oss'), $e->getMessage());
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -91,7 +91,6 @@ class Config
         self:: $urlAuthPrimaryKey =  $options['authPrimaryKey'];
         self:: $urlAuthAuxKey =  $options['authAuxKey'];
         self:: $urlAuthExpTime =  $options['authExpTime'] ;
-        self::initOssClient();
     }
 
     public static function monthDir($time)

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -6,21 +6,22 @@ class UrlHelper
 {
     protected $wpBaseUrl = "";
     protected $ossBaseUrl = "";
+
     public function __construct()
     {
         $this->wpBaseUrl = wp_get_upload_dir()['baseurl'];
         $this->ossBaseUrl = rtrim(Config::$staticHost . Config::$storePath, '/');
-        
+
         add_filter('oss_get_attachment_url', array($this, 'getOssUrl'), 9, 1);
         add_filter('oss_get_image_url', array($this, 'getOssImgUrl'), 9, 2);
-        add_filter('wp_get_attachment_url', array($this,'replaceAttachmentUrl'), 300, 2);
+        add_filter('wp_get_attachment_url', array($this, 'replaceAttachmentUrl'), 300, 2);
         add_filter('wp_calculate_image_srcset', array($this, 'replaceImgSrcsetUrl'), 300);
         if (Config::$enableImgService) {
             add_filter('wp_get_attachment_metadata', array($this, 'replaceImgMeta'), 900);
         }
-        add_filter( 'content_edit_pre',array($this,'ClassicUrlEditPre'), 10, 2 );//经典编辑器加载时,如果鉴权打开,则在内容加载时给链接添加鉴权信息     
-        add_filter( 'rest_prepare_post',array($this,'RestUrlEditPre'), 10, 3 );//古藤堡编辑器及其他依赖WP RESTapi的编辑器加载时,如果鉴权打开,则在内容加载时给链接添加鉴权信息
-        add_filter( 'content_save_pre',array($this,'imageUrlSavePre'));//保存内容时去掉鉴权信息,经过测试,如果经典编辑器运行在插件模式下时,此过滤器不起作用.古藤堡编辑器测试可用.
+        add_filter('content_edit_pre', array($this, 'ClassicUrlEditPre'), 10, 2);//经典编辑器加载时,如果鉴权打开,则在内容加载时给链接添加鉴权信息
+        add_filter('rest_prepare_post', array($this, 'RestUrlEditPre'), 10, 3);//古藤堡编辑器及其他依赖WP RESTapi的编辑器加载时,如果鉴权打开,则在内容加载时给链接添加鉴权信息
+        add_filter('content_save_pre', array($this, 'imageUrlSavePre'));//保存内容时去掉鉴权信息,经过测试,如果经典编辑器运行在插件模式下时,此过滤器不起作用.古藤堡编辑器测试可用.
     }
 
     /**
@@ -28,51 +29,52 @@ class UrlHelper
      *
      * @param $url
      * @return $url 返回带签名的url
-     * 
+     *
      * 如果设置中的url签名选项打开且鉴权类型为阿里云url鉴权A、B、C类型，则按对应鉴权类型对url添加签名信息
      */
     public function sign_url($url)
     {
         date_default_timezone_set('PRC');
-        $urlhost=parse_url($url, PHP_URL_SCHEME)."://".parse_url($url, PHP_URL_HOST); 
-        $filename = parse_url($url, PHP_URL_PATH);      
-        $expire_time= Config::$urlAuthExpTime;//set by hours
-        $key=Config::$urlAuthPrimaryKey;
-        if(Config::$enableUrlAuth && Config::$urlAuthMethod=="A"){
-            $time = strtotime("+".$expire_time." hours");
-            $sstring =$filename."-".$time."-0-0-".$key;
-            $md5=md5($sstring);
-            $auth_key="auth_key=".$time."-0-0-".$md5;
-            if(strstr($url,'?')){
-                $url = $url."&".$auth_key;
-            }else{
-                $url = $url."?".$auth_key;
-            }            
-        }
-        if(Config::$enableUrlAuth && Config::$urlAuthMethod=="B"){
-            $time=date("YmdHi",strtotime('+'.$expire_time.'hour'));
-            $sstring=$key.$time.$filename;
-            $md5=md5($sstring);            
-            if(strstr($url,'?')){
-                $url=explode("?",$url);
-                $url=$urlhost."/".$time."/".$md5.$filename."?".$url[1];
-            }else{
-                $url=$urlhost."/".$time."/".$md5.$filename;
-            }
-        } 
-        if(Config::$enableUrlAuth && Config::$urlAuthMethod=="C"){
-            $time=dechex(time()+ $expire_time*3600);
-            $sstring=$key.$filename.$time;
-            $md5=md5($sstring);
-            if(strstr($url,'?')){
-                $url=explode('?',$url);
-                $url=$urlhost."/".$md5."/".$time.$filename."?".$url[1];
-            }else{
-                $url=$urlhost."/".$md5."/".$time.$filename; 
+        $urlhost = parse_url($url, PHP_URL_SCHEME) . "://" . parse_url($url, PHP_URL_HOST);
+        $filename = parse_url($url, PHP_URL_PATH);
+        $expire_time = Config::$urlAuthExpTime;//set by hours
+        $key = Config::$urlAuthPrimaryKey;
+        if (Config::$enableUrlAuth && Config::$urlAuthMethod == "A") {
+            $time = strtotime("+" . $expire_time . " hours");
+            $sstring = $filename . "-" . $time . "-0-0-" . $key;
+            $md5 = md5($sstring);
+            $auth_key = "auth_key=" . $time . "-0-0-" . $md5;
+            if (strstr($url, '?')) {
+                $url = $url . "&" . $auth_key;
+            } else {
+                $url = $url . "?" . $auth_key;
             }
         }
-        return $url;  
+        if (Config::$enableUrlAuth && Config::$urlAuthMethod == "B") {
+            $time = date("YmdHi", strtotime('+' . $expire_time . 'hour'));
+            $sstring = $key . $time . $filename;
+            $md5 = md5($sstring);
+            if (strstr($url, '?')) {
+                $url = explode("?", $url);
+                $url = $urlhost . "/" . $time . "/" . $md5 . $filename . "?" . $url[1];
+            } else {
+                $url = $urlhost . "/" . $time . "/" . $md5 . $filename;
+            }
+        }
+        if (Config::$enableUrlAuth && Config::$urlAuthMethod == "C") {
+            $time = dechex(time() + $expire_time * 3600);
+            $sstring = $key . $filename . $time;
+            $md5 = md5($sstring);
+            if (strstr($url, '?')) {
+                $url = explode('?', $url);
+                $url = $urlhost . "/" . $md5 . "/" . $time . $filename . "?" . $url[1];
+            } else {
+                $url = $urlhost . "/" . $md5 . "/" . $time . $filename;
+            }
+        }
+        return $url;
     }
+
     /**
      * 将图片/附件 Url 替换为 OSS Url
      *
@@ -92,6 +94,7 @@ class UrlHelper
         $url = $this->sign_url($url);
         return $url;
     }
+
     /**
      * 将图片 Srcsets Url 替换为 OSS Url
      *
@@ -107,12 +110,13 @@ class UrlHelper
                 if (Config::$sourceImgProtect && (false === strstr($sources[$k]['url'], Config::$customSeparator))) {
                     $sources[$k]['url'] = $this->aliImageStyle($sources[$k]['url'], 'full');
                 }
-               
+
             }
-            $sources[$k]['url'] = $this->sign_url( $sources[$k]['url']);
+            $sources[$k]['url'] = $this->sign_url($sources[$k]['url']);
         }
         return $sources;
     }
+
     /**
      * 图片服务模式下, 修改图片元数据，以使用 Aliyun 的图片服务
      *
@@ -134,9 +138,9 @@ class UrlHelper
             } else {
                 $data['sizes'][$size]['file'] = $this->aliImageResize($basename, $info['height'], $info['width']);
             }
-            $url = $this->ossBaseUrl.'/'.$data['sizes'][$size]['file'];
+            $url = $this->ossBaseUrl . '/' . $data['sizes'][$size]['file'];
             $url = $this->sign_url($url);
-            $data['sizes'][$size]['file'] = str_replace($this->ossBaseUrl.'/','',$url);
+            $data['sizes'][$size]['file'] = str_replace($this->ossBaseUrl . '/', '', $url);
         }
         return $data;
     }
@@ -155,7 +159,7 @@ class UrlHelper
         if (empty($uri['host']) || false === strstr(Config::$staticHost, $uri['host'])) {
             $url = Config::$staticHost . Config::$storePath . '/' . ltrim($uri['path'], '/');
         }
-        $url = $this->sign_url($url);        
+        $url = $this->sign_url($url);
         return $url;
     }
 
@@ -219,24 +223,30 @@ class UrlHelper
     /**
      * fucntion RestUrlEditPre 在使用REST API的编辑器加载文章时修改文章url链接，添加鉴权信息
      * return 修改后的文章内容
-     * 
+     *
      * **/
-    public function RestUrlEditPre( $data, $post, $request ) {
-        if(!Config::$enableUrlAuth){return $data;}//如果鉴权关闭则返回
+    public function RestUrlEditPre($data, $post, $request)
+    {
+        if (!Config::$enableUrlAuth) {
+            return $data;
+        }//如果鉴权关闭则返回
         $content = $data->data['content']['raw'];
-        $content =  $this->ContentUrlAuth($content); 
-        $data->data['content']['raw']=$content;
+        $content = $this->ContentUrlAuth($content);
+        $data->data['content']['raw'] = $content;
         return $data;
     }
-    
+
     /**
      * fucntion ClassicUrlEditPre 在wp classic编辑器加载文章时修改文章url链接，添加鉴权信息
      * return 修改后的文章内容
-     * 
+     *
      * **/
-    public function ClassicUrlEditPre( $content, $post_id ) {
-        if(!Config::$enableUrlAuth){return $content;}//如果鉴权关闭则返回
-        $content =  $this->ContentUrlAuth($content); 
+    public function ClassicUrlEditPre($content, $post_id)
+    {
+        if (!Config::$enableUrlAuth) {
+            return $content;
+        }//如果鉴权关闭则返回
+        $content = $this->ContentUrlAuth($content);
         return $content;
     }
 
@@ -244,41 +254,48 @@ class UrlHelper
      * function ContentUrlAuth add auth for content
      * @param $content
      * @return $content
-     * 
+     *
      * **/
-    public function ContentUrlAuth($content){
-        if(!$content){return;}//内容为空时返回
-        $matches=preg_match_all('/<img.*? src=".*"\/>/',stripslashes($content),$imgs);
-        if($matches==0){return $content;}//如果data不包含图片文件则返回
-        foreach($imgs[0] as $val){
-            preg_match('/src="([^"]*)"/',var_export($val,true),$url);
-                if(!empty($url[0])){
-                    $url=$url[1];
-                    $url_auth= $this->sign_url($url);//对url添加鉴权
-                    $img_auth=str_replace($url,$url_auth,$val);//生成带鉴权url的img标签
-                    $content=str_replace($val,$img_auth,$content);//使用带鉴权img标签替换文章原有的img标签
-                }
+    public function ContentUrlAuth($content)
+    {
+        if (!$content) {
+            return;
+        }//内容为空时返回
+        $matches = preg_match_all('/<img.*? src=".*"\/>/', stripslashes($content), $imgs);
+        if ($matches == 0) {
+            return $content;
+        }//如果data不包含图片文件则返回
+        foreach ($imgs[0] as $val) {
+            preg_match('/src="([^"]*)"/', var_export($val, true), $url);
+            if (!empty($url[0])) {
+                $url = $url[1];
+                $url_auth = $this->sign_url($url);//对url添加鉴权
+                $img_auth = str_replace($url, $url_auth, $val);//生成带鉴权url的img标签
+                $content = str_replace($val, $img_auth, $content);//使用带鉴权img标签替换文章原有的img标签
+            }
         }
         return $content;
     }
-     /**
-      * function imageUrlSavePre 执行动作：移除cdn鉴权参数
+
+    /**
+     * function imageUrlSavePre 执行动作：移除cdn鉴权参数
      * @param $content 输入编辑器内容;
      * @return $content;
      */
-    public function imageUrlSavePre($content){//该方法暂时只适用于A方式
-        if(Config::$enableUrlAuth||1){//如果鉴权打开则进行操作
-            $matches=preg_match_all('/<img.*? src=".*"\/>/',stripslashes($content),$imgs);
-            if($matches>0){
-                foreach($imgs[0] as $val){
-                preg_match('/auth_key.*(?=".*alt)/',var_export($val,true),$auth_key);
-                    if(!empty($auth_key[0])){
-                        $content=str_replace('?'.$auth_key[0],'',$content); 
-                        $content=str_replace('&amp;'.$auth_key[0],'',$content);              
+    public function imageUrlSavePre($content)
+    {//该方法暂时只适用于A方式
+        if (Config::$enableUrlAuth || 1) {//如果鉴权打开则进行操作
+            $matches = preg_match_all('/<img.*? src=".*"\/>/', stripslashes($content), $imgs);
+            if ($matches > 0) {
+                foreach ($imgs[0] as $val) {
+                    preg_match('/auth_key.*(?=".*alt)/', var_export($val, true), $auth_key);
+                    if (!empty($auth_key[0])) {
+                        $content = str_replace('?' . $auth_key[0], '', $content);
+                        $content = str_replace('&amp;' . $auth_key[0], '', $content);
                     }
                 }
             }
-        }        
+        }
         return $content;
     }
 }


### PR DESCRIPTION
使用 Gutenburg 的图片编辑后，图片未能上传到 OSS
<img width="962" alt="截屏2023-01-14 下午4 59 53" src="https://user-images.githubusercontent.com/13096985/212464472-1fc48970-7bf0-42ef-9a27-4586e1bcd340.png">

经检查发现，Gutenburg 使用了 WordPress Rest API v2 进行图片修改，而在 `Config::initOssClient()` 函数使用了 `is_admin()` 来判断是否在 admin 页面中

![WechatIMG84757](https://user-images.githubusercontent.com/13096985/212464619-6a064983-6f57-4b1b-81e4-a0c4b671e963.jpeg)

但是这个函数在 rest-api 中始终返回 `false` 且 `$_FILES` 返回为 0，导致 `ossClient` 无法初始化，从而无法上传图片。

![WechatIMG84756](https://user-images.githubusercontent.com/13096985/212464630-58f042df-bb5d-4f52-a9f4-2604961b338e.jpeg)

解决思路是使用 `current_user_can` 和 `defined( 'REST_REQUEST' )` 优化权限的验证，同时调整了入口对插件函数初始化时的优先级。


